### PR TITLE
feat: fetch more data

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -13,14 +13,24 @@ describe("should checks an URL", () => {
         new Response(JSON.stringify(expectedJson))
       )
     );
+    const expectedJsonToken = {"token":"toto","url":"https://toto.beta.gouv.fr","alias":"","last_status":200,"uptime":100.0,"down":false,"down_since":null,"error":null,"period":60,"apdex_t":0.5,"string_match":"","enabled":true,"published":true,"disabled_locations":[],"last_check_at":"2021-05-06T10:55:17Z","next_check_at":"2021-05-06T10:56:16Z","mute_until":null,"favicon_url":"https://www.fabrique.social.gouv.fr/images/favicons/favicon-16x16.png","custom_headers":{},"http_verb":"GET/HEAD","http_body":"","ssl":{"tested_at":"2021-05-06T10:55:17Z","expires_at":"2021-06-21T16:16:37Z","valid":true,"error":null},"metrics":{"apdex":1.0,"timings":{"redirect":0,"namelookup":106,"connection":125,"handshake":262,"response":132,"total":624}}}
+    fetch.mockImplementationOnce(() =>
+      Promise.resolve(
+        new Response(JSON.stringify(expectedJsonToken))
+      )
+    );
     const result = await checks("https://toto.beta.gouv.fr", "testKey");
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledTimes(2);
     expect(fetch).toHaveBeenNthCalledWith(
       1,
       "https://updown.io/api/checks?api-key=testKey"
     );
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      "https://updown.io/api/checks/toto?api-key=testKey&metrics=true"
+    );
     expect(result.url).toEqual("https://toto.beta.gouv.fr");
-    expect(result).toEqual(expectedJson[0]);
+    expect(result).toEqual(expectedJsonToken);
   });
 
   test("should return error invalid api key", async () => {


### PR DESCRIPTION
Fetch detailed check data from updown.io

This adds `metrics` key with apdex and average response time data (based on last hour metrics)

```json
{
 ...
  "metrics": {
    "apdex": 1.0,
    "timings": {
       "redirect": 0,
       "namelookup": 106,
       "connection":125,
       "handshake": 262,
       "response": 132,
       "total": 624
     }
  }
}
```
fix #4